### PR TITLE
Describe vexar as what it now is

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Studied aerospace, ended up building software.
 
 ### Products
 
-- **[Vexar](https://nhatvu148.dev/#projects)**<br>Agentic coding assistant in Rust. Autonomous multi-step tasks over a semantically indexed codebase; desktop and CLI share ~90% of the code.
+- **[Vexar](https://nhatvu148.dev/#projects)**<br>Multi-agent cockpit in Rust. Run `claude`, `gemini` or `codex` in parallel, each isolated in its own git worktree, and review and merge from one screen.
 - **[Whisgram](https://whisgram.nvnv.app)**<br>Video → study notes: summaries, concept diagrams, flashcards. Chrome extension + web app. Agents can pay for it directly over x402.
 - **[SIMCEL](https://simcel.io)**<br>Day job: supply chain digital twin for Fortune 500s. Simulates promotions, disruptions, and market shifts.
 


### PR DESCRIPTION
The Products line for vexar was false in every clause:

> Agentic coding assistant in Rust. Autonomous multi-step tasks over a semantically indexed codebase; desktop and CLI share ~90% of the code.

- **not an agent** — it orchestrates them. The agent is your own `claude` / `gemini` / `codex`, running in a terminal vexar hosts, in a git worktree vexar isolates.
- **no semantic index** — removed, ~7,000 lines and 109 transitive crates.
- **no CLI** — the crate was deleted; a vexar-branded chat CLI was the same category error as its chat tab.

Replaced with a line that matches the terse style of the Whisgram and SIMCEL entries beside it.

https://claude.ai/code/session_01CPmfjCC9k2M5S1HsmVJ48x